### PR TITLE
Enable CORS for background removal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ uvicorn app:app --reload
 ```
 
 Open `http://localhost:8000` in your browser to use the app.
+
+The API has CORS enabled, so the `/remove-bg` endpoint can be called from other
+web applications hosted on different origins.

--- a/app.py
+++ b/app.py
@@ -1,9 +1,17 @@
 from fastapi import FastAPI, File, UploadFile, HTTPException
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import Response
 from rembg import remove
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB


### PR DESCRIPTION
## Summary
- allow cross-origin requests by adding FastAPI CORS middleware
- document that the API can be called from other origins

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c203e1b2cc833292e7f0f908944886