### PR TITLE
Add browser-only UI for background removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,23 @@ A simple web application that removes the background from uploaded images. Image
 **drag-and-drop**. Files larger than **10 MB** are rejected. The interface shows a preview of the selected image and lets
 you download the processed result.
 
-## Setup
+## Using the client-side demo
+
+Open `static/index.html` directly in your browser. The page uses the
+[`@imgly/background-removal`](https://www.npmjs.com/package/@imgly/background-removal)
+library to remove backgrounds **entirely in the browser** – no local server is
+required.
+
+## Running the API server (optional)
+
+If you prefer a Python backend, install the dependencies and run the FastAPI app:
 
 ```bash
 pip install -r requirements.txt
 uvicorn app:app --reload
 ```
 
-Open `http://localhost:8000` in your browser to use the app.
+Then open `http://localhost:8000` in your browser.
 
 The API has CORS enabled, so the `/remove-bg` endpoint can be called from other
 web applications hosted on different origins.

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Background Remover</title>
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <h1>Background Remover</h1>
@@ -18,6 +18,6 @@
         <img id="preview" alt="Preview" />
         <a id="download-link" href="#" download="output.png">Download</a>
     </div>
-    <script src="/static/script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,9 +1,12 @@
+import { removeBackground } from 'https://cdn.jsdelivr.net/npm/@imgly/background-removal@1.7.0/dist/index.mjs';
+
 const dropZone = document.getElementById('drop-zone');
 const fileInput = document.getElementById('file-input');
 const removeBtn = document.getElementById('remove-btn');
 const preview = document.getElementById('preview');
 const inputPreview = document.getElementById('input-preview');
 const downloadLink = document.getElementById('download-link');
+const CDN_PUBLIC_PATH = 'https://cdn.jsdelivr.net/npm/@imgly/background-removal@1.7.0/dist/';
 let selectedFile = null;
 
 dropZone.addEventListener('click', () => fileInput.click());
@@ -40,18 +43,13 @@ removeBtn.addEventListener('click', async () => {
         alert('File too large. Max size is 10MB.');
         return;
     }
-    const formData = new FormData();
-    formData.append('file', selectedFile);
-    const response = await fetch('/remove-bg', {
-        method: 'POST',
-        body: formData
-    });
-    if (!response.ok) {
+    try {
+        const blob = await removeBackground(selectedFile, { publicPath: CDN_PUBLIC_PATH });
+        const url = URL.createObjectURL(blob);
+        preview.src = url;
+        downloadLink.href = url;
+    } catch (err) {
+        console.error(err);
         alert('Error removing background');
-        return;
     }
-    const blob = await response.blob();
-    const url = URL.createObjectURL(blob);
-    preview.src = url;
-    downloadLink.href = url;
 });


### PR DESCRIPTION
## Summary
- Use `@imgly/background-removal` so the UI works directly in the browser without a backend
- Serve static assets with relative paths and module script for easy standalone use
- Document client-side demo alongside optional FastAPI server

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2bd5761848332ac030debf0f21027