### PR TITLE
Serve client demo from repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ you download the processed result.
 
 ## Using the client-side demo
 
-Open `static/index.html` directly in your browser. The page uses the
-[`@imgly/background-removal`](https://www.npmjs.com/package/@imgly/background-removal)
+Open `index.html` directly in your browser (or host the repository with GitHub Pages).
+The page uses the [`@imgly/background-removal`](https://www.npmjs.com/package/@imgly/background-removal)
 library to remove backgrounds **entirely in the browser** – no local server is
-required.
+required. The supporting CSS and JavaScript live in the `static/` folder so the
+same files work when served from the bundled FastAPI app.
 
 ## Running the API server (optional)
 

--- a/app.py
+++ b/app.py
@@ -31,5 +31,6 @@ async def remove_bg(file: UploadFile = File(...)):
 
 @app.get("/")
 async def root():
-    with open("static/index.html", "r", encoding="utf-8") as f:
+    """Serve the client-side demo."""
+    with open("index.html", "r", encoding="utf-8") as f:
         return Response(content=f.read(), media_type="text/html")

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Background Remover</title>
-    <link rel="stylesheet" href="style.css">
+    <!-- Reference assets from the static folder so GitHub Pages and the FastAPI server can share them -->
+    <link rel="stylesheet" href="static/style.css">
 </head>
 <body>
     <h1>Background Remover</h1>
@@ -18,6 +19,6 @@
         <img id="preview" alt="Preview" />
         <a id="download-link" href="#" download="output.png">Download</a>
     </div>
-    <script type="module" src="script.js"></script>
+    <script type="module" src="static/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `index.html` at repository root so GitHub Pages loads UI
- update FastAPI to serve the new root index and share static assets
- refresh README with hosting instructions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2bfcc60e483329748ba6383213163