### PR TITLE
fix: fetch model resources from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ you download the processed result.
 
 Open `index.html` directly in your browser (or host the repository with GitHub Pages).
 The page bundles the [`@imgly/background-removal`](https://www.npmjs.com/package/@imgly/background-removal)
-library and runs **entirely in the browser** – no network calls or local server are
-required. The supporting CSS and JavaScript live in the `static/` folder so the
-same files work when served from the optional FastAPI app.
+library and downloads its model data from Img.Ly's CDN at runtime. The supporting
+CSS and JavaScript live in the `static/` folder so the same files work when
+served from the optional FastAPI app.
 
 ## Running the API server (optional)
 

--- a/static/script.js
+++ b/static/script.js
@@ -6,8 +6,6 @@ const removeBtn = document.getElementById('remove-btn');
 const preview = document.getElementById('preview');
 const inputPreview = document.getElementById('input-preview');
 const downloadLink = document.getElementById('download-link');
-// Resolve the path to the local background-removal resources relative to this script
-const LOCAL_PUBLIC_PATH = new URL('./libs/background-removal/', import.meta.url).href;
 let selectedFile = null;
 
 dropZone.addEventListener('click', () => fileInput.click());
@@ -45,7 +43,7 @@ removeBtn.addEventListener('click', async () => {
         return;
     }
     try {
-        const blob = await removeBackground(selectedFile, { publicPath: LOCAL_PUBLIC_PATH });
+        const blob = await removeBackground(selectedFile);
         const url = URL.createObjectURL(blob);
         preview.src = url;
         downloadLink.href = url;


### PR DESCRIPTION
## Summary
- remove usage of local background-removal resources and rely on CDN
- clarify README about loading model data from Img.ly CDN

## Testing
- `python -m py_compile app.py`
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c315efd3bc833281501ebdfa7cd553