### PR TITLE
Fix background removal by using CDN models

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -43,7 +43,9 @@ removeBtn.addEventListener('click', async () => {
         return;
     }
     try {
-        const blob = await removeBackground(selectedFile);
+        const blob = await removeBackground(selectedFile, {
+            publicPath: "https://cdn.jsdelivr.net/npm/@imgly/background-removal@latest/dist/"
+        });
         const url = URL.createObjectURL(blob);
         preview.src = url;
         downloadLink.href = url;


### PR DESCRIPTION
## Summary
- load background removal model data from Img.Ly's CDN to avoid missing resource errors

## Testing
- `python -m py_compile app.py`
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c317dc89088332aa9ebed34b3e8a2a