### PR TITLE
fix: match background-removal CDN to bundled version

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -44,7 +44,7 @@ removeBtn.addEventListener('click', async () => {
     }
     try {
         const blob = await removeBackground(selectedFile, {
-            publicPath: "https://cdn.jsdelivr.net/npm/@imgly/background-removal@latest/dist/"
+            publicPath: "https://cdn.jsdelivr.net/npm/@imgly/background-removal@1.7.0/dist/"
         });
         const url = URL.createObjectURL(blob);
         preview.src = url;


### PR DESCRIPTION
## Summary
- fix model loading path by pinning CDN resources to bundled library version

## Testing
- `node --check static/script.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c331c31e848332a0275d80fbaa85b7