### PR TITLE
Use backend for background removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,13 @@
 # Background Removal Web App
 
-A simple web application that removes the background from uploaded images. Images can be uploaded via file selection or
-**drag-and-drop**. Files larger than **10 MB** are rejected. The interface shows a preview of the selected image and lets
-you download the processed result.
+A simple web application that removes the background from uploaded images using a
+FastAPI backend powered by the `rembg` library. Images can be uploaded via file
+selection or **drag-and-drop**. Files larger than **10 MB** are rejected. The interface
+shows a preview of the selected image and lets you download the processed result.
 
-## Using the client-side demo
+## Running the app
 
-Open `index.html` directly in your browser (or host the repository with GitHub Pages).
-The page bundles the [`@imgly/background-removal`](https://www.npmjs.com/package/@imgly/background-removal)
-library and downloads its model data from Img.Ly's CDN at runtime. The supporting
-CSS and JavaScript live in the `static/` folder so the same files work when
-served from the optional FastAPI app.
-
-## Running the API server (optional)
-
-If you prefer a Python backend, install the dependencies and run the FastAPI app:
+Install the dependencies and run the FastAPI app:
 
 ```bash
 pip install -r requirements.txt
@@ -23,5 +16,5 @@ uvicorn app:app --reload
 
 Then open `http://localhost:8000` in your browser.
 
-The API has CORS enabled, so the `/remove-bg` endpoint can be called from other
-web applications hosted on different origins.
+The static files live in the `static/` folder and call the `/remove-bg`
+endpoint to process images.

--- a/static/script.js
+++ b/static/script.js
@@ -1,5 +1,3 @@
-import { removeBackground } from './libs/background-removal/index.mjs';
-
 const dropZone = document.getElementById('drop-zone');
 const fileInput = document.getElementById('file-input');
 const removeBtn = document.getElementById('remove-btn');
@@ -43,18 +41,22 @@ removeBtn.addEventListener('click', async () => {
         return;
     }
     try {
-        const blob = await removeBackground(selectedFile, {
-            publicPath: "https://cdn.jsdelivr.net/npm/@imgly/background-removal@1.7.0/dist/"
+        const formData = new FormData();
+        formData.append('file', selectedFile);
+        const response = await fetch('/remove-bg', {
+            method: 'POST',
+            body: formData,
         });
+        if (!response.ok) {
+            throw new Error(`Server returned ${response.status}`);
+        }
+        const blob = await response.blob();
         const url = URL.createObjectURL(blob);
         preview.src = url;
         downloadLink.href = url;
     } catch (err) {
         console.error(err);
         const message = err?.message || err;
-        const cause = err?.cause;
-        const causeMsg = cause ? (cause.message || String(cause)) : '';
-        const fullMsg = `Error removing background: ${message}` + (causeMsg ? `\nCause: ${causeMsg}` : '');
-        alert(fullMsg);
+        alert(`Error removing background: ${message}`);
     }
 });


### PR DESCRIPTION
## Summary
- Replace client-side model usage with a server call to `/remove-bg`
- Document backend-powered workflow in README

## Testing
- `python -m py_compile app.py`
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c35c8789388332bc7465553bd35c84