### PR TITLE
fix: use relative API path for GitHub Pages

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -43,7 +43,9 @@ removeBtn.addEventListener('click', async () => {
     try {
         const formData = new FormData();
         formData.append('file', selectedFile);
-        const response = await fetch('/remove-bg', {
+        // Use a relative URL so the request also works when the site is
+        // hosted under a subdirectory (e.g. on GitHub Pages).
+        const response = await fetch('remove-bg', {
             method: 'POST',
             body: formData,
         });


### PR DESCRIPTION
## Summary
- use relative URL for `/remove-bg` endpoint to support subdirectory hosting (e.g. GitHub Pages)

## Testing
- `python -m py_compile app.py && node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c360bca0d48332a035b0b3d91265fb