### PR TITLE
feat: enable client-side background removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # Background Removal Web App
 
-A simple web application that removes the background from uploaded images using a
-FastAPI backend powered by the `rembg` library. Images can be uploaded via file
-selection or **drag-and-drop**. Files larger than **10 MB** are rejected. The interface
-shows a preview of the selected image and lets you download the processed result.
+A simple web application that removes the background from uploaded images.
+Images can be uploaded via file selection or **drag-and-drop**. Files larger
+than **10 MB** are rejected. The interface shows a preview of the selected image
+and lets you download the processed result.
 
-## Running the app
+By default, background removal happens directly in the browser using a
+WebAssembly model. This means the site can be hosted on static hosts such as
+GitHub Pages without any backend server.
 
-Install the dependencies and run the FastAPI app:
+## Running locally with FastAPI
+
+If you still want to run the old server-based variant, install the
+dependencies and start the FastAPI app:
 
 ```bash
 pip install -r requirements.txt
 uvicorn app:app --reload
 ```
 
-Then open `http://localhost:8000` in your browser.
-
-The static files live in the `static/` folder and call the `/remove-bg`
-endpoint to process images.
+Then open `http://localhost:8000` in your browser. The static files live in the
+`static/` folder.

--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,5 @@
+import { removeBackground } from './libs/background-removal/index.mjs';
+
 const dropZone = document.getElementById('drop-zone');
 const fileInput = document.getElementById('file-input');
 const removeBtn = document.getElementById('remove-btn');
@@ -41,18 +43,7 @@ removeBtn.addEventListener('click', async () => {
         return;
     }
     try {
-        const formData = new FormData();
-        formData.append('file', selectedFile);
-        // Use a relative URL so the request also works when the site is
-        // hosted under a subdirectory (e.g. on GitHub Pages).
-        const response = await fetch('remove-bg', {
-            method: 'POST',
-            body: formData,
-        });
-        if (!response.ok) {
-            throw new Error(`Server returned ${response.status}`);
-        }
-        const blob = await response.blob();
+        const blob = await removeBackground(selectedFile);
         const url = URL.createObjectURL(blob);
         preview.src = url;
         downloadLink.href = url;


### PR DESCRIPTION
## Summary
- use WebAssembly library to remove backgrounds directly in the browser
- document client-side usage and keep optional FastAPI server instructions

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/removebg/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c4387916908332a5a04147b8c6903c