### PR TITLE
fix: load onnxruntime-web via import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,14 @@
         <img id="preview" alt="Preview" />
         <a id="download-link" href="#" download="output.png">Download</a>
     </div>
+    <script type="importmap">
+    {
+        "imports": {
+            "onnxruntime-web": "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.21.0/dist/ort.min.js",
+            "onnxruntime-web/webgpu": "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.21.0/dist/ort-webgpu.min.js"
+        }
+    }
+    </script>
     <script type="module" src="static/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load onnxruntime-web and webgpu variants from CDN using import map

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c464eba23c83329e4922638d8f4e17